### PR TITLE
Several improvements to beacon

### DIFF
--- a/beacon/beacon.cabal
+++ b/beacon/beacon.cabal
@@ -23,6 +23,12 @@ executable beacon
   hs-source-dirs:   app
   main-is:          beacon.hs
   default-language: GHC2021
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
   build-depends:
     , ansi-terminal
     , base
@@ -35,6 +41,7 @@ executable beacon
     , extra
     , optparse-applicative
     , process
+    , slugger
     , text
     , vector
     , vector-algorithms


### PR DESCRIPTION
- Allow specifying the compiler used to build `db-analyser`.
- Add the starting slot number and number of processed blocks to the .csv so that changes in these result in new `db-analyser` runs.