### PR TITLE
beacon: repair file extensions that were slugged

### DIFF
--- a/beacon/app/beacon.hs
+++ b/beacon/app/beacon.hs
@@ -286,14 +286,13 @@ compareMeasurements opts header csvA csvB = do
       (Just outliers)
       csvA
       csvB
-      ( toSlug
-        $ Text.unpack header
-       <> "-"
-       <> (versionA opts).dbAnalyser
-       <> "_vs_"
-       <> (versionB opts).dbAnalyser
-       <> ".png"
-      )
+      $ toSlug (
+      Text.unpack header
+        <> "-"
+        <> (versionA opts).dbAnalyser
+        <> "_vs_"
+        <> (versionB opts).dbAnalyser
+      ) <> ".png"
     where
       -- Given two runs and a column name, return the relative change, sorted in
       -- ascending order.
@@ -446,12 +445,12 @@ runBenchmarks opts InstallInfo { installPath, installedVersion } = do
     unlessM (doesFileExist outfile) run
     pure $ BenchmarkRunDataPath { benchmarkRunDataPath = outfile }
   where
-    outfile = toSlug $
-                "ledger-ops-cost-"
-                <> vToFilePath installedVersion
-                <> "-from_" <> show (analyseFromSlot opts)
-                <> "-nr_blocks_" <> show (numBlocksToProcess opts)
-                <> ".csv"
+    outfile = toSlug (
+      "ledger-ops-cost-"
+        <> vToFilePath installedVersion
+        <> "-from_" <> show (analyseFromSlot opts)
+        <> "-nr_blocks_" <> show (numBlocksToProcess opts)
+      ) <> ".csv"
 
     vToFilePath version =
       version.dbAnalyser <> "-" <> version.compiler


### PR DESCRIPTION
Beacon outputs `csv` files with names like:

```
ledger-ops-cost-e3917f684e8b60e7bfc453d6d8114b800bdf167d-haskell-from-63-nr-blocks-100-csv
ledger-ops-cost-e3917f684e8b60e7bfc453d6d8114b800bdf167d-haskell810-from-63-nr-blocks-100-csv
ledger-ops-cost-e3917f684e8b60e7bfc453d6d8114b800bdf167d-haskell810-from-63-nr-blocks-100000-csv
ledger-ops-cost-e3917f684e8b60e7bfc453d6d8114b800bdf167d-haskell96-from-63-nr-blocks-100000-csv
```

notice the `-csv` instead of `.csv`. This also occurs for the `png` files it produces:
```
mut-blockapply-e3917f684e8b60e7bfc453d6d8114b800bdf167d-vs-e3917f684e8b60e7bfc453d6d8114b800bdf167d-png
mut-forecast-e3917f684e8b60e7bfc453d6d8114b800bdf167d-vs-e3917f684e8b60e7bfc453d6d8114b800bdf167d-png
```

Why? Because the `.` get slugged:
```
    outfile = toSlug $
                "ledger-ops-cost-"
                <> vToFilePath installedVersion
                <> "-from_" <> show (analyseFromSlot opts)
                <> "-nr_blocks_" <> show (numBlocksToProcess opts)
                <> ".csv"
```
and
```
      ( toSlug
        $ Text.unpack header
       <> "-"
       <> (versionA opts).dbAnalyser
       <> "_vs_"
       <> (versionB opts).dbAnalyser
       <> ".png"
      )
```

This PR fixes that bug.